### PR TITLE
Adicionando automação de rádio button com Cypress

### DIFF
--- a/cypress/e2e/form-fill-automation.cy.js
+++ b/cypress/e2e/form-fill-automation.cy.js
@@ -114,5 +114,46 @@ describe('Testando a página de Checkboxes', () => {
     cy.get('.rct-node').contains('Desktop').parent().find('input[type="checkbox"]').should('be.checked');
     cy.get('.rct-node').contains('Notes').parent().find('input[type="checkbox"]').should('be.checked');
   });
+
+describe('Automação da tela Radio Button - ToolsQA', () => {
+    beforeEach(() => {
+      // Ignorar erros de exceção não capturados
+      Cypress.on('uncaught:exception', (err, runnable) => false);
+  
+      // Visitar a página de Radio Button
+      cy.visit('https://demoqa.com/radio-button', { failOnStatusCode: false });
+    });
+  
+    it('Verifica a visibilidade dos botões de rádio', () => {
+      // Verifica se os rótulos associados estão visíveis
+      cy.get('label[for="yesRadio"]').should('be.visible');
+      cy.get('label[for="impressiveRadio"]').should('be.visible');
+      cy.get('label[for="noRadio"]').should('be.visible');
+      
+      // Verifica se o botão "No" está desabilitado
+      cy.get('input#noRadio').should('be.disabled');
+    });
+  
+    it('Seleciona o botão de rádio "Yes"', () => {
+      // Clica no rótulo associado ao botão "Yes"
+      cy.get('label[for="yesRadio"]').click();
+      // Verifica a mensagem de confirmação
+      cy.get('.mt-3').should('contain', 'Yes');
+    });
+  
+    it('Seleciona o botão de rádio "Impressive"', () => {
+      // Clica no rótulo associado ao botão "Impressive"
+      cy.get('label[for="impressiveRadio"]').click();
+      // Verifica a mensagem de confirmação
+      cy.get('.mt-3').should('contain', 'Impressive');
+    });
+  
+    it('Verifica que o botão de rádio "No" está desabilitado', () => {
+      // Verifica que o botão "No" está presente, mas desabilitado
+      cy.get('input#noRadio').should('be.disabled');
+      cy.get('label[for="noRadio"]').should('be.visible');
+    });
+  });
+  
   
 });


### PR DESCRIPTION
# Adicionando automação da tela Radio Button com Cypress

## Descrição
Este commit adiciona testes automatizados para a página **Radio Button** do site ToolsQA utilizando Cypress. Os testes garantem o funcionamento correto da seleção de botões de rádio e a validação de mensagens exibidas.

## Mudanças Realizadas
- Implementação de testes para verificar a visibilidade dos botões de rádio:
  - "Yes"
  - "Impressive"
  - "No" (desabilitado)
- Validação da funcionalidade de seleção para os botões:
  - Seleção do botão "Yes" e verificação da mensagem correspondente.
  - Seleção do botão "Impressive" e verificação da mensagem correspondente.
- Validação de que o botão "No" está desabilitado.

## Tecnologias Utilizadas
- **Cypress**: Framework de testes end-to-end.
- Uso do seletor `label` para interação com os botões invisíveis (`opacity: 0`).

## Testes Realizados
1. Verificação da visibilidade dos botões de rádio.
2. Seleção dos botões "Yes" e "Impressive" com validação das mensagens exibidas.
3. Confirmação de que o botão "No" está desabilitado.

## Notas
- Garantir que o ambiente esteja configurado com as dependências do Cypress antes de rodar os testes.

## Links Relacionados
- [Página Radio Button - ToolsQA](https://demoqa.com/radio-button)
